### PR TITLE
Permit to build Intel Mac

### DIFF
--- a/cmetrics.go
+++ b/cmetrics.go
@@ -1,4 +1,4 @@
-//go:build !(darwin && arm64)
+//go:build linux
 
 package cmetrics
 

--- a/cmetrics_darwin.go
+++ b/cmetrics_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package cmetrics
 
 /*


### PR DESCRIPTION
C.ulonglong's byte type glitches exists in Intel Mac, too.
I tested on Intel Mac and M1 Mac this patch.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>