### PR TITLE
Support raw struct cmt pointer handling and translate into Context type

### DIFF
--- a/cmetrics.go
+++ b/cmetrics.go
@@ -296,3 +296,19 @@ func NewContext() (*Context, error) {
 	}
 	return &Context{context: cmt}, nil
 }
+
+func NewRawCMTPointer() (unsafe.Pointer, error) {
+	cmt := C.cmt_create()
+	if cmt == nil {
+		return nil, errors.New("cannot create cmt context")
+	}
+	return unsafe.Pointer(cmt), nil
+}
+
+func NewContextFromCMTPointer(cmt unsafe.Pointer) (*Context, error) {
+	if cmt == nil {
+		return nil, errors.New("Cannot create Context from nil")
+	}
+	ctx := (*C.struct_cmt)(cmt)
+	return &Context{context: ctx}, nil
+}


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Some of bridging between fluent-bit and Golang plugin mechanism should be needed to handle/translate raw struct cmt pointers.
We should expose raw struct cmt pointers handling, shouldn't we?

In addition, Context type's `context` field is private qualified field.
We have to provide some operations for handling/translating from `struct cmt` pointers into this module's `Context` type variables.